### PR TITLE
Update swift-format to apple's repo

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -1,16 +1,20 @@
 class SwiftFormat < Formula
   desc "Formatting technology for Swift source code"
-  homepage "https://github.com/NSHipster/swift-format"
-  url "https://github.com/NSHipster/swift-format.git", :branch => "master"
-  head "https://github.com/NSHipster/swift-format.git", :shallow => false
+  homepage "https://github.com/apple/swift-format"
+  url "https://github.com/apple/swift-format.git", :branch => "swift-5.1-branch"
+  version "swift-5.1-branch"
+  head "https://github.com/apple/swift-format.git"
 
   depends_on :xcode => ["11.0", :build]
 
   def install
-    system "make", "install", "prefix=#{prefix}"
+    system "swift", "build", "--disable-sandbox", "-c", "release"
+    bin.install ".build/release/swift-format"
+    doc.install "Documentation/Configuration.md"
   end
 
   test do
-    system "#{bin}/swift-format"
+    (testpath/"test.swift").write " print(  \"Hello, World\"  ) ;"
+    assert_equal "print(\"Hello, World\")\n", shell_output("#{bin}/swift-format test.swift")
   end
 end


### PR DESCRIPTION
This PR updates the `swift-format` formula to use [apple/swift-format](https://github.com/apple/swift-format), as apple's repo is constantly updated.