### PR TITLE
Add version to SwiftFormat formula

### DIFF
--- a/Formula/swift-format.rb
+++ b/Formula/swift-format.rb
@@ -3,6 +3,7 @@ class SwiftFormat < Formula
   homepage "https://github.com/NSHipster/swift-format"
   url "https://github.com/NSHipster/swift-format.git", :branch => "master"
   head "https://github.com/NSHipster/swift-format.git", :shallow => false
+  version "master"
 
   depends_on :xcode => ["11.0", :build]
 


### PR DESCRIPTION
Fixes #3. Due to recent changes to Homebrew (see Homebrew/homebrew-core#51073 and Homebrew/brew#7110 for details), the SwiftFormat formula needs to be updated to include a version attribute.

Tested by running
```shell
$ brew tap nshipster/formulae https://github.com/ndmeiri/homebrew-formulae
```
and then
```shell
$ brew install nshipster/formulae/swift-format
```
And here's the full output:
```shell
$ brew tap nshipster/formulae https://github.com/ndmeiri/homebrew-formulae
==> Tapping nshipster/formulae
Cloning into '/usr/local/Homebrew/Library/Taps/nshipster/homebrew-formulae'...
remote: Enumerating objects: 44, done.
remote: Counting objects: 100% (44/44), done.
remote: Compressing objects: 100% (35/35), done.
remote: Total 89 (delta 15), reused 15 (delta 5), pack-reused 45
Unpacking objects: 100% (89/89), done.
Tapped 8 formulae (122 files, 69.7KB).
$ brew uninstall nshipster/formulae/swift-format
Uninstalling /usr/local/Cellar/swift-format/format... (5 files, 9.7MB)
$ brew install nshipster/formulae/swift-format
==> Installing swift-format from nshipster/formulae
==> Cloning https://github.com/NSHipster/swift-format.git
Updating /Users/Naji/Library/Caches/Homebrew/swift-format--git
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 74375bc Add Makefile
==> make install prefix=/usr/local/Cellar/swift-format/master
🍺  /usr/local/Cellar/swift-format/master: 5 files, 9.7MB, built in 3 minutes 14 seconds
```

I'm not sure of the appropriate version for the other formulae, so I updated swift-format.rb only.