### PR TITLE
Fix installation issue with swift-gyb

### DIFF
--- a/Formula/swift-gyb.rb
+++ b/Formula/swift-gyb.rb
@@ -14,7 +14,6 @@ class SwiftGyb < Formula
     system "swift", "build",
            "--configuration", "release",
            "--disable-sandbox",
-           "-Xswiftc",
            "--build-path", buildpath.to_s
 
     bin.install buildpath/"release/swift-gyb" => "swift-gyb"

--- a/Formula/swift-gyb.rb
+++ b/Formula/swift-gyb.rb
@@ -14,7 +14,7 @@ class SwiftGyb < Formula
     system "swift", "build",
            "--configuration", "release",
            "--disable-sandbox",
-           "-Xswiftc", "-static-stdlib",
+           "-Xswiftc",
            "--build-path", buildpath.to_s
 
     bin.install buildpath/"release/swift-gyb" => "swift-gyb"


### PR DESCRIPTION
Howdy,

I tried installing the `swift-gyb` formula earlier and was slapped back with the following error:

```
==> Installing nshipster/formulae/swift-gyb
==> swift build --configuration release --disable-sandbox -Xswiftc -static-stdlib --build-path /private/tmp/swift-gyb-20210705-87129-vj2tao
Last 15 lines from /Users/REDACTED/Library/Logs/Homebrew/swift-gyb/01.swift:
-Xswiftc
-static-stdlib
--build-path
/private/tmp/swift-gyb-20210705-87129-vj2tao

/private/tmp/swift-gyb-20210705-87129-vj2tao: warning: failed loading manifest for 'swift-gyb-20210705-87129-vj2tao' from cache: unknown system error while operating on /Users/REDACTED/Library/Caches/org.swift.swiftpm/manifests/manifest.db.lock
/private/tmp/swift-gyb-20210705-87129-vj2tao: warning: failed storing manifest for 'swift-gyb-20210705-87129-vj2tao' in cache: unknown system error while operating on /Users/REDACTED/Library/Caches/org.swift.swiftpm/manifests/manifest.db.lock
Fetching https://github.com/apple/swift-package-manager.git from cache
Skipping cache due to an error: unknown system error while operating on /Users/REDACTED/Library/Caches/org.swift.swiftpm/repositories.lock
Cloning https://github.com/apple/swift-package-manager.git
Resolving https://github.com/apple/swift-package-manager.git at 0.3.0
/private/tmp/swift-gyb-20210705-87129-vj2tao/checkouts/swift-package-manager: warning: failed loading manifest for 'swift-package-manager' from cache: unknown system error while operating on /Users/REDACTED/Library/Caches/org.swift.swiftpm/manifests/manifest.db.lock
/private/tmp/swift-gyb-20210705-87129-vj2tao/checkouts/swift-package-manager: warning: failed storing manifest for 'swift-package-manager' in cache: unknown system error while operating on /Users/REDACTED/Library/Caches/org.swift.swiftpm/manifests/manifest.db.lock
[1/2] Compiling clibc libc.c
<unknown>:0: error: -static-stdlib is no longer supported on Apple platforms
```

As inferred from the wall of text, dropping the `-static-stdlib` flag (and also `-Xswiftc` flag, for reasons beyond me) allows the formula to be installed again. I double checked by tapping this formula repo to my fork a la:

```
$ brew tap nshipster/formulae https://github.com/ShezHsky/homebrew-formulae
```

And then gave the installer a spin once more:

```
$ brew install nshipster/formulae/swift-gyb
```

And low and behold:

```
REDACTED@REDACTED-iMac Formula % brew tap nshipster/formulae https://github.com/ShezHsky/homebrew-formulae
==> Tapping nshipster/formulae
Cloning into '/usr/local/Homebrew/Library/Taps/nshipster/homebrew-formulae'...
remote: Enumerating objects: 154, done.
remote: Counting objects: 100% (56/56), done.
remote: Compressing objects: 100% (40/40), done.
remote: Total 154 (delta 19), reused 46 (delta 16), pack-reused 98
Receiving objects: 100% (154/154), 43.13 KiB | 1.96 MiB/s, done.
Resolving deltas: 100% (52/52), done.
Tapped 8 formulae (22 files, 60KB).
REDACTED@REDACTED-iMac Formula % brew install nshipster/formulae/swift-gyb
==> Installing swift-gyb from nshipster/formulae
==> Cloning https://github.com/NSHipster/swift-gyb.git
Updating /Users/REDACTED/Library/Caches/Homebrew/swift-gyb--git
==> Checking out tag 0.1.0
HEAD is now at eebe89d Add Installation section to README
HEAD is now at eebe89d Add Installation section to README
==> swift build --configuration release --disable-sandbox --build-path /private/tmp/swift-gyb-20210705-89521-afx4e8
🍺  /usr/local/Cellar/swift-gyb/0.1.0: 5 files, 1.6MB, built in 32 seconds
```

I've not been "behind the bar" with Homebrew before, so to speak, but hopefully this is legit!